### PR TITLE
Removed unicode identifier to ensure Python 3 compatibility.

### DIFF
--- a/sphinx_me.py
+++ b/sphinx_me.py
@@ -166,7 +166,7 @@ def setup_conf(conf_globals):
         "release": version,
         "project": project_path.rstrip(sep).split(sep)[-1],
         "master_doc": "index",
-        "copyright": u"%s, %s" % (datetime.now().year, author),
+        "copyright": "%s, %s" % (datetime.now().year, author),
     }
     pad = max([len(k) for k in settings.keys()]) + 3
     print()


### PR DESCRIPTION
Hi Stephen,

Because django-email-extras relies on sphinx-me, I need this application to be python 3 compatible as well. Seems only one change is needed.
Could you merge this and release a new pypi package? (and also release a new pypi package for django-email-extras?)

Thanks,
Thomas
